### PR TITLE
Update README.md to fix typo on include statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ For official [Box Turtle](https://github.com/ArmoredTurtle/BoxTurtle) Software, 
 1. Copy the `KlipperScreen Menus` folder into your `~/printer_data/config/`
 2. Add `[include KlipperScreen Menus/*]` to your `Klipperscreen.conf`
 3. Add `BTKS_Macros.cfg` to your macro folder or to `~/printer_data/config/`
-   - Add `[include BTSK_Macros.cfg]` to your `printer.cfg` if it is not added to a folder that is included in your `printer.cfg`
+   - Add `[include BTKS_Macros.cfg]` to your `printer.cfg` if it is not added to a folder that is included in your `printer.cfg`
 4. Service restart Klipper
 5. Restart Klipperscreen


### PR DESCRIPTION
corrected type on include statement

from `[include BTSK_Macros.cfg]`
to `[include BTKS_Macros]`